### PR TITLE
Put in pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Username: `admin`
 
 Password: `password`
 
+## Pre-requisites for running the application
+You will require the pg_config binary, which will usually be included with a postgres package. The libpq-dev package will also be required on Debian machines.
+You will require ruby v2.3.0 or higher
+You will require bundler
+```
+gem install bundler
+```
+
 ## Installation
 
 Installation is really simple. First, we'd like to install any dependencies required by the blog.


### PR DESCRIPTION
I got segfaults when using Ruby version 2.2.0 or lower, which looks like it is a combination of the ruby version, nokogiri, and some other library. Upgrading my ruby version sorted stuff out, so probably worth making it explicity in the docs so others don't have to spend too much time waiting for things to install, retrying, etc
